### PR TITLE
Brush cleanup

### DIFF
--- a/Problems/prob001/models/car.mzn.metadata
+++ b/Problems/prob001/models/car.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob001/models/carSequencing.eprime.metadata
+++ b/Problems/prob001/models/carSequencing.eprime.metadata
@@ -1,3 +1,0 @@
----
-Type: EssencePrime
----

--- a/Problems/prob003/models/quasiGroup3Idempotent.mzn.metadata
+++ b/Problems/prob003/models/quasiGroup3Idempotent.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob003/models/quasiGroup3NonIdempotent.mzn.metadata
+++ b/Problems/prob003/models/quasiGroup3NonIdempotent.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob003/models/quasiGroup4Idempotent.mzn.metadata
+++ b/Problems/prob003/models/quasiGroup4Idempotent.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob003/models/quasiGroup4NonIdempotent.mzn.metadata
+++ b/Problems/prob003/models/quasiGroup4NonIdempotent.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob003/models/quasiGroup5Idempotent.mzn.metadata
+++ b/Problems/prob003/models/quasiGroup5Idempotent.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob003/models/quasiGroup5NonIdempotent.mzn.metadata
+++ b/Problems/prob003/models/quasiGroup5NonIdempotent.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob003/models/quasiGroup7.mzn.metadata
+++ b/Problems/prob003/models/quasiGroup7.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob007/models/all_interval.eprime.metadata
+++ b/Problems/prob007/models/all_interval.eprime.metadata
@@ -1,3 +1,0 @@
----
-Type: EssencePrime
----

--- a/Problems/prob007/models/all_interval.mzn.metadata
+++ b/Problems/prob007/models/all_interval.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob007/models/all_interval1.mzn.metadata
+++ b/Problems/prob007/models/all_interval1.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob007/models/all_interval2.mzn.metadata
+++ b/Problems/prob007/models/all_interval2.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob007/models/all_interval3.mzn.metadata
+++ b/Problems/prob007/models/all_interval3.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob007/models/all_interval4.mzn.metadata
+++ b/Problems/prob007/models/all_interval4.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob007/models/all_interval5.mzn.metadata
+++ b/Problems/prob007/models/all_interval5.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob007/models/all_interval6.mzn.metadata
+++ b/Problems/prob007/models/all_interval6.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob010/models/social_golfers1.mzn.metadata
+++ b/Problems/prob010/models/social_golfers1.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob012/models/nonogram_create_automaton2.mzn.metadata
+++ b/Problems/prob012/models/nonogram_create_automaton2.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob016/models/traffic_lights.eprime.metadata
+++ b/Problems/prob016/models/traffic_lights.eprime.metadata
@@ -1,3 +1,0 @@
----
-Type: EssencePrime
----

--- a/Problems/prob016/models/traffic_lights.mzn.metadata
+++ b/Problems/prob016/models/traffic_lights.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob016/models/traffic_lights_table.mzn.metadata
+++ b/Problems/prob016/models/traffic_lights_table.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob018/models/water_buckets1.mzn.metadata
+++ b/Problems/prob018/models/water_buckets1.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob018/models/water_buckets_regular.mzn.metadata
+++ b/Problems/prob018/models/water_buckets_regular.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob019/models/magic.mzn.metadata
+++ b/Problems/prob019/models/magic.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob019/models/magic_sequence.mzn.metadata
+++ b/Problems/prob019/models/magic_sequence.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob019/models/magic_sequence2.mzn.metadata
+++ b/Problems/prob019/models/magic_sequence2.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob019/models/magic_sequence3.mzn.metadata
+++ b/Problems/prob019/models/magic_sequence3.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob019/models/magic_sequence4.mzn.metadata
+++ b/Problems/prob019/models/magic_sequence4.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob019/models/magic_square.mzn.metadata
+++ b/Problems/prob019/models/magic_square.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob021/models/crossfigure.mzn.metadata
+++ b/Problems/prob021/models/crossfigure.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob022/models/bus_scheduling_csplib.mzn.metadata
+++ b/Problems/prob022/models/bus_scheduling_csplib.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob023/models/magic_hexagon.mzn.metadata
+++ b/Problems/prob023/models/magic_hexagon.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob024/models/langford2.mzn.metadata
+++ b/Problems/prob024/models/langford2.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob032/models/maximum_density_still_life.mzn.metadata
+++ b/Problems/prob032/models/maximum_density_still_life.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob039/models/rehearsal.mzn.metadata
+++ b/Problems/prob039/models/rehearsal.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob041/models/fractions.mzn.metadata
+++ b/Problems/prob041/models/fractions.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob044/models/steiner.mzn.metadata
+++ b/Problems/prob044/models/steiner.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob049/models/set_partition.eprime.metadata
+++ b/Problems/prob049/models/set_partition.eprime.metadata
@@ -1,3 +1,0 @@
----
-Type: EssencePrime
----

--- a/Problems/prob049/models/set_partition.mzn.metadata
+++ b/Problems/prob049/models/set_partition.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob050/models/diamond_free_degree_sequence.mzn.metadata
+++ b/Problems/prob050/models/diamond_free_degree_sequence.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob054/models/nqueens.eprime.metadata
+++ b/Problems/prob054/models/nqueens.eprime.metadata
@@ -1,3 +1,0 @@
----
-Type: EssencePrime
----

--- a/Problems/prob054/models/queens3.mzn.metadata
+++ b/Problems/prob054/models/queens3.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob054/models/queens5.mzn.metadata
+++ b/Problems/prob054/models/queens5.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob056/models/sonet_problem.mzn.metadata
+++ b/Problems/prob056/models/sonet_problem.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob057/models/killer_sudoku.eprime.metadata
+++ b/Problems/prob057/models/killer_sudoku.eprime.metadata
@@ -1,3 +1,0 @@
----
-Type: EssencePrime
----

--- a/Problems/prob057/models/killer_sudoku.mzn.metadata
+++ b/Problems/prob057/models/killer_sudoku.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob057/models/killer_sudoku2.mzn.metadata
+++ b/Problems/prob057/models/killer_sudoku2.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/Problems/prob067/models/QuasigroupCompletion.mzn.metadata
+++ b/Problems/prob067/models/QuasigroupCompletion.mzn.metadata
@@ -1,3 +1,0 @@
----
-Type: MiniZinc
----

--- a/internal/scripts/framework/generate_web_site.py
+++ b/internal/scripts/framework/generate_web_site.py
@@ -33,7 +33,7 @@ from distutils import dir_util
 from jinja2 import Environment, FileSystemLoader
 
 from problem import Problem, PageType
-from util import create_zip_file, makedirs_exist_ok
+from util import create_zip_file, makedirs_exist_ok, source_mapping
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +206,13 @@ for prob in probs:
 		raise
 
 mdx_prob_link.PROB_DATA=PROB_DATA
+
+# Fill in extension -> filetype mappings
+for lang in langs:
+    (_,meta) = util.convert_markdown(lang.specification)
+    if 'extensions' in meta:
+        for ext in meta['extensions']:
+            util.source_mapping[ext] = meta['title'][0].lower()
 
 generate_pages(probs)
 generate_pages(langs)

--- a/internal/templates/file.html
+++ b/internal/templates/file.html
@@ -27,7 +27,7 @@
     SyntaxHighlighter.autoloader(
     ['essence','param','solution', '{{prefix_path}}/js/shBrushEssence.js'],
     ['essenceprime', '{{prefix_path}}/js/shBrushEssencePrime.js'],
-    ['minizinc','mzn', '{{prefix_path}}/js/shBrushMiniZinc.js'],
+    ['minizinc', '{{prefix_path}}/js/shBrushMiniZinc.js'],
     ['comet','co', '{{prefix_path}}/js/shBrushComet.js'],
     ['js','javascript','{{prefix_path}}/syntax_highlighter/shBrushJScript.js'],
     ['cpp','hpp','hh','cc','h','c', '{{prefix_path}}/syntax_highlighter/shBrushCpp.js'],


### PR DESCRIPTION
This removes the need to add metadata files for extensions which we know (like mzn and eprime).