### PR TITLE
Add SWI-Prolog CLP and backtracking models for prob067 (Quasigroup Completion)

### DIFF
--- a/Problems/prob067/models/quasigroup_completion_swi_backtracking.pl
+++ b/Problems/prob067/models/quasigroup_completion_swi_backtracking.pl
@@ -1,0 +1,45 @@
+% Example instance: a partially pre-filled 7x7 quasigroup (_ = empty cell).
+% Passed to the solver as an argument (see quasigroup/2) so the same relation
+% completes any board, mirroring how the MiniZinc references take the board as
+% data rather than wiring it into the model.
+partially_quasigroup([
+    [1, _, _, 4, _, _, _],
+    [_, 3, _, _, _, 7, _],
+    [_, _, 5, _, _, _, 2],
+    [4, _, _, 7, _, _, _],
+    [_, 6, _, _, 2, _, _],
+    [_, _, 1, _, _, 4, _],
+    [7, _, _, 3, _, _, 6]
+]).
+
+% quasigroup(+Puzzle, -Solution): completes the partially filled Puzzle into
+% Solution. Solution shares the grid with Puzzle, so empty cells get bound here.
+quasigroup(Puzzle, Solution):-
+    Solution = Puzzle,
+    length(Solution, M),
+    numlist(1, M, Domain),
+    maplist(fill_row_dc(Domain, Solution), Solution).
+
+
+% fill_row_dc(+Domain, +Solution, +Row): assign the empty cells of Row
+fill_row_dc(Domain, Solution, Row):-
+    include(nonvar, Row, Prefilled), % collect prefilled values
+    subtract(Domain, Prefilled, Reduced),  % remove prefilled from domain
+    assign_cell_dc(Row, Reduced, 1, Solution).
+
+% assign_cell_dc(+Row, +Remaining, +Index, +Solution): fill each cell of Row from Remaining
+assign_cell_dc([], _Remaining, _Index, _Solution).
+assign_cell_dc([Cell|Rest], Remaining, Index, Solution):-
+    nonvar(Cell), % cell pre-filled
+    NextIndex is Index + 1,
+    assign_cell_dc(Rest, Remaining, NextIndex, Solution).
+
+assign_cell_dc([Cell|Rest], Remaining, Index, Solution) :-
+    var(Cell),
+    maplist(nth1(Index), Solution, Col),      % extract the column for the given index
+    include(nonvar, Col, ColUsed),            % collect already filled column values
+    subtract(Remaining, ColUsed, Candidates), % candidates = row domain minus column values
+    member(Cell, Candidates),                 % cell empty -> assign from restricted domain
+    select(Cell, Remaining, NewRemaining),    % update remaining row values
+    NextIndex is Index + 1,
+    assign_cell_dc(Rest, NewRemaining, NextIndex, Solution).

--- a/Problems/prob067/models/quasigroup_completion_swi_backtracking.pl.metadata
+++ b/Problems/prob067/models/quasigroup_completion_swi_backtracking.pl.metadata
@@ -1,0 +1,4 @@
+---
+Title: SWI-Prolog backtracking model
+Type: SWI-Prolog
+---

--- a/Problems/prob067/models/quasigroup_completion_swi_clp.pl
+++ b/Problems/prob067/models/quasigroup_completion_swi_clp.pl
@@ -1,0 +1,30 @@
+:- use_module(library(clpfd)).
+
+% Example instance: a partially pre-filled 7x7 quasigroup (_ = empty cell).
+% The solver takes the puzzle as an argument (see quasigroup/2), so the same
+% relation completes any board. This fact is just one concrete instance to run
+% it on, mirroring how the MiniZinc references pass the board in as data.
+partially_quasigroup([
+    [1, _, _, 4, _, _, _],
+    [_, 3, _, _, _, 7, _],
+    [_, _, 5, _, _, _, 2],
+    [4, _, _, 7, _, _, _],
+    [_, 6, _, _, 2, _, _],
+    [_, _, 1, _, _, 4, _],
+    [7, _, _, 3, _, _, 6]
+]).
+
+% quasigroup(+Puzzle, -Solution): completes the partially filled Puzzle into a
+% full Latin square. The holes in Puzzle are unbound variables, so unifying
+% Solution with Puzzle lets the constraints fill them in place.
+quasigroup(Puzzle, Solution):-
+    Solution = Puzzle,
+    length(Solution, M),
+    append(Solution, Vars), % flatten the matrix into a single list and restrict every cell (every element in Vars) to 1-M.
+    Vars ins 1..M,
+
+    maplist(all_distinct, Solution), % all elements in a row must be distinct
+    transpose(Solution, Transposed),
+    maplist(all_distinct, Transposed), % all elements in a col must be distinct
+
+    label(Vars).

--- a/Problems/prob067/models/quasigroup_completion_swi_clp.pl.metadata
+++ b/Problems/prob067/models/quasigroup_completion_swi_clp.pl.metadata
@@ -1,0 +1,4 @@
+---
+Title: SWI-Prolog CLP(FD) model
+Type: SWI-Prolog
+---


### PR DESCRIPTION
Adds two SWI-Prolog models for the Quasigroup Completion problem (prob067), for which there is currently no Prolog solution in the library:

- quasigroup_completion_swi_clp.pl: a CLP(FD) model using all_distinct/1 on rows and columns.
- quasigroup_completion_swi_backtracking.pl: a backtracking solver with up-front row and column domain restriction.

Both take the puzzle as an argument, so the same relation completes any board.
The example board is included as a fact only to make the file runnable as-is.

On the bundled 7x7 instance with 15 pre-filled cells, the two solvers agree and enumerate all 42 completions. I also cross-checked this count against the repository's QuasigroupCompletion.mzn model run on the same instance, which also gives 42.
